### PR TITLE
Fix prefLabel for new CMPO 0000457 terms

### DIFF
--- a/cmpo-simple.owl
+++ b/cmpo-simple.owl
@@ -7326,7 +7326,7 @@ Micronucleation, i.e. presumably nuclear envelopes around single chromosomes or 
         <oboInOwl:id>CMPO:0000457</oboInOwl:id>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/subset/cmpo#cmpo"/>
         <rdfs:label>decreased nucleus to cell area ratio</rdfs:label>
-        <skos:prefLabel xml:lang="en">increased nucleus to cell area ratio</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">decreased nucleus to cell area ratio</skos:prefLabel>
     </owl:Class>
     
 

--- a/cmpo.obo
+++ b/cmpo.obo
@@ -3639,7 +3639,7 @@ name: decreased nucleus to cell area ratio
 def: "A population of cells where there is is an increased number of cells with a decreased nucleus to cell area ratio" []
 subset: cmpo
 is_a: CMPO:0000163 ! cell population phenotype by morphology
-property_value: prefLabel "increased nucleus to cell area ratio" xsd:string
+property_value: prefLabel "decreased nucleus to cell area ratio" xsd:string
 
 [Term]
 id: CMPO:0000458

--- a/src/ontology/cmpo-edit.owl
+++ b/src/ontology/cmpo-edit.owl
@@ -17178,7 +17178,7 @@ Micronucleation, i.e. presumably nuclear envelopes around single chromosomes or 
         <oboInOwl:id>CMPO:0000457</oboInOwl:id>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/subset/cmpo#cmpo"/>
         <rdfs:label>decreased nucleus to cell area ratio</rdfs:label>
-        <skos:prefLabel xml:lang="en">increased nucleus to cell area ratio</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">decreased nucleus to cell area ratio</skos:prefLabel>
     </owl:Class>
     
 


### PR DESCRIPTION
See also #4 

While trying to update https://idr.openmicroscopy.org/webclient/?show=screen-1801 to use the new CMPO terms, I realized the `prefLabel` in https://www.ebi.ac.uk/ols/ontologies/cmpo/terms?short_form=CMPO_0000457 was wrong. /cc @eleanorwilliams
